### PR TITLE
Use textContent instead of innerHTML

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -5,24 +5,24 @@ const ENDPOINT = 'https://api16-normal-useast5.us.tiktokv.com/media/api/text/spe
 const setError = (message) => {
     clearAudio()
     document.getElementById('error').style.display = 'block'
-    document.getElementById('errortext').innerHTML = message
+    document.getElementById('errortext').textContent = message
 }
 
 const clearError = () => {
     document.getElementById('error').style.display = 'none'
-    document.getElementById('errortext').innerHTML = 'There was an error.'
+    document.getElementById('errortext').textContent = 'There was an error.'
 }
 
 const setAudio = (base64, text) => {
     document.getElementById('success').style.display = 'block'
     document.getElementById('audio').src = `data:audio/mpeg;base64,${base64}`
-    document.getElementById('generatedtext').innerHTML = `"${text}"`
+    document.getElementById('generatedtext').textContent = `"${text}"`
 }
 
 const clearAudio = () => {
     document.getElementById('success').style.display = 'none'
     document.getElementById('audio').src = ``
-    document.getElementById('generatedtext').innerHTML = ''
+    document.getElementById('generatedtext').textContent = ''
 }
 
 const submitForm = () => {


### PR DESCRIPTION
Replaced all instances of `Node.innerHTML` with `Node.textContent`. `Node.innerHTML` is an unsafe way of setting user generated text, as it allows for arbitrary injection of html tags.